### PR TITLE
129 replace psutil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ tests = [
     "coverage",
     "pytest-cov",
     "mypy",
-    "psutil",
 ]
 lint = [
     "ruff"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,22 @@
 """Common fixtures for testing."""
 
+import os
+
 import pytest
-from numpy.random import default_rng
+from numpy.random import Generator, default_rng
 
 
 @pytest.fixture
-def rng():
+def max_cpu_count() -> int:
+    """Returns the maximum number of CPU cores available."""
+
+    max_cpu: int = os.cpu_count()
+    if max_cpu is None:
+        max_cpu = 1
+    return max_cpu
+
+
+@pytest.fixture
+def rng() -> Generator:
+    """Returns a random number generator with a fixed seed for reproducibility."""
     return default_rng(seed=42)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,7 @@ from numpy.random import Generator, default_rng
 @pytest.fixture
 def max_cpu_count() -> int:
     """Returns the maximum number of CPU cores available."""
-
-    max_cpu: int = os.cpu_count()
-    if max_cpu is None:
-        max_cpu = 1
-    return max_cpu
+    return os.cpu_count() or 1
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,14 @@ from numpy.random import Generator, default_rng
 
 @pytest.fixture
 def max_cpu_count() -> int:
-    """Returns the maximum number of CPU cores available."""
-    return os.cpu_count() or 1
+    """Returns the maximum number of CPUs available to the process."""
+    if hasattr(os, "process_cpu_count"):
+        cpu_count = os.process_cpu_count()
+    elif hasattr(os, "sched_getaffinity"):
+        cpu_count = len(os.sched_getaffinity(0))
+    else:
+        cpu_count = os.cpu_count()
+    return cpu_count or 1
 
 
 @pytest.fixture

--- a/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_fft_kernel_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_fft_kernel_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from scipy.fft import irfftn, rfftn
@@ -44,16 +42,15 @@ class FFTSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_scipy_fft(n_values, precision, rng):
+def test_scipy_fft(n_values, precision, rng, max_cpu_count):
     solution = FFTSolution(n_values, rng_generator=rng, precision=precision)
     fourier_field = np.zeros_like(solution.ref_fourier_field)
     inv_fourier_field = np.zeros_like(solution.ref_inv_fourier_field)
-    max_num_threads = multiprocessing.cpu_count()
     fft_ifft_via_scipy_kernel_2d(
         fourier_field,
         inv_fourier_field,
         solution.ref_field,
-        num_threads=max_num_threads,
+        num_threads=max_cpu_count,
     )
     # assert correct
     solution.check_equals(fourier_field, inv_fourier_field)
@@ -61,11 +58,10 @@ def test_scipy_fft(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_pyfftw_fft(n_values, precision, rng):
+def test_pyfftw_fft(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = FFTSolution(n_values, rng_generator=rng, precision=precision)
-    max_num_threads = multiprocessing.cpu_count()
-    pyfftw = FFTPyFFTW2D(n_values, n_values, num_threads=max_num_threads, real_t=real_t)
+    pyfftw = FFTPyFFTW2D(n_values, n_values, num_threads=max_cpu_count, real_t=real_t)
     fourier_field = np.zeros_like(solution.ref_fourier_field)
     inv_fourier_field = np.zeros_like(solution.ref_inv_fourier_field)
     pyfftw.fft_plan(input_array=solution.ref_field, output_array=fourier_field)

--- a/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_fft_kernel_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_fft_kernel_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from scipy.fft import irfftn, rfftn
 from sopht.numeric.eulerian_grid_ops import (
@@ -47,7 +48,7 @@ def test_scipy_fft(n_values, precision, rng):
     solution = FFTSolution(n_values, rng_generator=rng, precision=precision)
     fourier_field = np.zeros_like(solution.ref_fourier_field)
     inv_fourier_field = np.zeros_like(solution.ref_inv_fourier_field)
-    max_num_threads = psutil.cpu_count(logical=False)
+    max_num_threads = multiprocessing.cpu_count()
     fft_ifft_via_scipy_kernel_2d(
         fourier_field,
         inv_fourier_field,
@@ -63,7 +64,7 @@ def test_scipy_fft(n_values, precision, rng):
 def test_pyfftw_fft(n_values, precision, rng):
     real_t = get_real_t(precision)
     solution = FFTSolution(n_values, rng_generator=rng, precision=precision)
-    max_num_threads = psutil.cpu_count(logical=False)
+    max_num_threads = multiprocessing.cpu_count()
     pyfftw = FFTPyFFTW2D(n_values, n_values, num_threads=max_num_threads, real_t=real_t)
     fourier_field = np.zeros_like(solution.ref_fourier_field)
     inv_fourier_field = np.zeros_like(solution.ref_inv_fourier_field)

--- a/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_unbounded_poisson_solver_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_unbounded_poisson_solver_2d.py
@@ -1,6 +1,7 @@
+import multiprocessing
+
 import numpy as np
 import numpy.linalg as la
-import psutil
 import pytest
 from scipy.fft import irfftn, rfftn
 from sopht.numeric.eulerian_grid_ops import (
@@ -88,7 +89,7 @@ def test_unbounded_poisson_solve_pyfftw_2d(n_values, precision, rng):
         grid_size_x=n_values,
         x_range=x_range,
         real_t=real_t,
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     solution_field = np.zeros_like(solution.rhs_field)
     unbounded_poisson_solver_kernel = unbounded_poisson_solver.solve

--- a/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_unbounded_poisson_solver_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_unbounded_poisson_solver_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import numpy.linalg as la
 import pytest
@@ -74,7 +72,7 @@ class UnboundedPoissonSolverSolution2D:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_unbounded_poisson_solve_pyfftw_2d(n_values, precision, rng):
+def test_unbounded_poisson_solve_pyfftw_2d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     x_range = real_t(2.0)
     solution = UnboundedPoissonSolverSolution2D(
@@ -89,7 +87,7 @@ def test_unbounded_poisson_solve_pyfftw_2d(n_values, precision, rng):
         grid_size_x=n_values,
         x_range=x_range,
         real_t=real_t,
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     solution_field = np.zeros_like(solution.rhs_field)
     unbounded_poisson_solver_kernel = unbounded_poisson_solver.solve

--- a/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_3d/test_fft_kernel_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_3d/test_fft_kernel_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from scipy.fft import irfftn, rfftn
 from sopht.numeric.eulerian_grid_ops import (
@@ -43,7 +44,7 @@ def test_scipy_fft_3d(n_values, precision, rng):
     solution = FFTSolution(rng_generator=rng, n_samples=n_values, precision=precision)
     fourier_field = np.zeros_like(solution.ref_fourier_field)
     inv_fourier_field = np.zeros_like(solution.ref_inv_fourier_field)
-    max_num_threads = psutil.cpu_count(logical=False)
+    max_num_threads = multiprocessing.cpu_count()
     fft_ifft_via_scipy_kernel_3d(
         fourier_field,
         inv_fourier_field,
@@ -59,7 +60,7 @@ def test_scipy_fft_3d(n_values, precision, rng):
 def test_pyfftw_fft_3d(n_values, precision, rng):
     real_t = get_real_t(precision)
     solution = FFTSolution(rng_generator=rng, n_samples=n_values, precision=precision)
-    max_num_threads = psutil.cpu_count(logical=False)
+    max_num_threads = multiprocessing.cpu_count()
     pyfftw = FFTPyFFTW3D(n_values, n_values, n_values, num_threads=max_num_threads, real_t=real_t)
     fourier_field = np.zeros_like(solution.ref_fourier_field)
     inv_fourier_field = np.zeros_like(solution.ref_inv_fourier_field)

--- a/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_3d/test_fft_kernel_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_3d/test_fft_kernel_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from scipy.fft import irfftn, rfftn
@@ -40,16 +38,15 @@ class FFTSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [8])
-def test_scipy_fft_3d(n_values, precision, rng):
+def test_scipy_fft_3d(n_values, precision, rng, max_cpu_count):
     solution = FFTSolution(rng_generator=rng, n_samples=n_values, precision=precision)
     fourier_field = np.zeros_like(solution.ref_fourier_field)
     inv_fourier_field = np.zeros_like(solution.ref_inv_fourier_field)
-    max_num_threads = multiprocessing.cpu_count()
     fft_ifft_via_scipy_kernel_3d(
         fourier_field,
         inv_fourier_field,
         solution.ref_field,
-        num_threads=max_num_threads,
+        num_threads=max_cpu_count,
     )
     # assert correct
     solution.check_equals(fourier_field, inv_fourier_field)
@@ -57,11 +54,10 @@ def test_scipy_fft_3d(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [8])
-def test_pyfftw_fft_3d(n_values, precision, rng):
+def test_pyfftw_fft_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = FFTSolution(rng_generator=rng, n_samples=n_values, precision=precision)
-    max_num_threads = multiprocessing.cpu_count()
-    pyfftw = FFTPyFFTW3D(n_values, n_values, n_values, num_threads=max_num_threads, real_t=real_t)
+    pyfftw = FFTPyFFTW3D(n_values, n_values, n_values, num_threads=max_cpu_count, real_t=real_t)
     fourier_field = np.zeros_like(solution.ref_fourier_field)
     inv_fourier_field = np.zeros_like(solution.ref_inv_fourier_field)
     pyfftw.fft_plan(input_array=solution.ref_field, output_array=fourier_field)

--- a/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_3d/test_unbounded_poisson_solver_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_3d/test_unbounded_poisson_solver_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from scipy.fft import irfftn, rfftn
 from sopht.numeric.eulerian_grid_ops import (
@@ -118,7 +119,7 @@ def test_unbounded_poisson_solve_pyfftw_3d(n_values, precision, rng):
         grid_size_x=n_values,
         x_range=x_range,
         real_t=real_t,
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     solution_field = np.zeros_like(solution.rhs_field)
     unbounded_poisson_solver_kernel = unbounded_poisson_solver.solve
@@ -146,7 +147,7 @@ def test_unbounded_vector_field_poisson_solve_pyfftw_3d(n_values, precision, rng
         grid_size_x=n_values,
         x_range=x_range,
         real_t=real_t,
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     solution_vector_field = np.zeros_like(solution.rhs_vector_field)
     unbounded_poisson_solver_kernel = unbounded_poisson_solver.vector_field_solve

--- a/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_3d/test_unbounded_poisson_solver_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_3d/test_unbounded_poisson_solver_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from scipy.fft import irfftn, rfftn
@@ -102,7 +100,7 @@ class UnboundedPoissonSolverSolution3D:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_unbounded_poisson_solve_pyfftw_3d(n_values, precision, rng):
+def test_unbounded_poisson_solve_pyfftw_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     x_range = real_t(2.0)
     solution = UnboundedPoissonSolverSolution3D(
@@ -119,7 +117,7 @@ def test_unbounded_poisson_solve_pyfftw_3d(n_values, precision, rng):
         grid_size_x=n_values,
         x_range=x_range,
         real_t=real_t,
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     solution_field = np.zeros_like(solution.rhs_field)
     unbounded_poisson_solver_kernel = unbounded_poisson_solver.solve
@@ -130,7 +128,7 @@ def test_unbounded_poisson_solve_pyfftw_3d(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_unbounded_vector_field_poisson_solve_pyfftw_3d(n_values, precision, rng):
+def test_unbounded_vector_field_poisson_solve_pyfftw_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     x_range = real_t(2.0)
     solution = UnboundedPoissonSolverSolution3D(
@@ -147,7 +145,7 @@ def test_unbounded_vector_field_poisson_solve_pyfftw_3d(n_values, precision, rng
         grid_size_x=n_values,
         x_range=x_range,
         real_t=real_t,
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     solution_vector_field = np.zeros_like(solution.rhs_vector_field)
     unbounded_poisson_solver_kernel = unbounded_poisson_solver.vector_field_solve

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_advection_flux_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_advection_flux_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -113,7 +111,7 @@ class AdvectionFluxSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_advection_flux_conservative_eno3(n_values, precision, rng):
+def test_advection_flux_conservative_eno3(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = AdvectionFluxSolution(
         rng, n_values, flux_type="conservative_eno3", precision=precision
@@ -122,7 +120,7 @@ def test_advection_flux_conservative_eno3(n_values, precision, rng):
     advection_flux_conservative_eno3_kernel = gen_advection_flux_conservative_eno3_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     advection_flux_conservative_eno3_kernel(
         advection_flux=advection_flux,

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_advection_flux_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_advection_flux_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_advection_flux_conservative_eno3_pyst_kernel_2d,
@@ -121,7 +122,7 @@ def test_advection_flux_conservative_eno3(n_values, precision, rng):
     advection_flux_conservative_eno3_kernel = gen_advection_flux_conservative_eno3_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     advection_flux_conservative_eno3_kernel(
         advection_flux=advection_flux,

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_advection_timestep_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_advection_timestep_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -58,7 +56,7 @@ class AdvectionTimestepSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_euler_forward_conservative_eno3_2d(n_values, precision, rng):
+def test_euler_forward_conservative_eno3_2d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = AdvectionTimestepSolution(
         rng,
@@ -73,7 +71,7 @@ def test_euler_forward_conservative_eno3_2d(n_values, precision, rng):
         gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     field = solution.ref_field.copy()

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_advection_timestep_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_advection_timestep_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_2d,
@@ -72,7 +73,7 @@ def test_euler_forward_conservative_eno3_2d(n_values, precision, rng):
         gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     field = solution.ref_field.copy()

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_brinkmann_penalise_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_brinkmann_penalise_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_brinkmann_penalise_pyst_kernel_2d,
@@ -74,7 +75,7 @@ def test_brinkmann_penalise_scalar_field_2d(n_values, precision, rng):
     brinkmann_penalise_pyst_kernel = gen_brinkmann_penalise_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     brinkmann_penalise_pyst_kernel(
@@ -96,7 +97,7 @@ def test_brinkmann_penalise_vector_field_2d(n_values, precision, rng):
     brinkmann_penalise_vector_field_pyst_kernel = gen_brinkmann_penalise_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     brinkmann_penalise_vector_field_pyst_kernel(
@@ -119,7 +120,7 @@ def test_brinkmann_penalise_scalar_field_vs_fixed_val_2d(n_values, precision, rn
         gen_brinkmann_penalise_vs_fixed_val_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
             field_type="scalar",
         )
     )
@@ -149,7 +150,7 @@ def test_brinkmann_penalise_vector_field_vs_fixed_val_2d(n_values, precision, rn
         gen_brinkmann_penalise_vs_fixed_val_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
             field_type="vector",
         )
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_brinkmann_penalise_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_brinkmann_penalise_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -68,14 +66,14 @@ class BrinkmannPenalisationSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_brinkmann_penalise_scalar_field_2d(n_values, precision, rng):
+def test_brinkmann_penalise_scalar_field_2d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = BrinkmannPenalisationSolution(rng, n_values, precision)
     penalised_field = np.zeros_like(solution.ref_penalised_field)
     brinkmann_penalise_pyst_kernel = gen_brinkmann_penalise_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     brinkmann_penalise_pyst_kernel(
@@ -90,14 +88,14 @@ def test_brinkmann_penalise_scalar_field_2d(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_brinkmann_penalise_vector_field_2d(n_values, precision, rng):
+def test_brinkmann_penalise_vector_field_2d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = BrinkmannPenalisationSolution(rng, n_values, precision)
     penalised_vector_field = np.zeros_like(solution.ref_penalised_vector_field)
     brinkmann_penalise_vector_field_pyst_kernel = gen_brinkmann_penalise_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     brinkmann_penalise_vector_field_pyst_kernel(
@@ -112,7 +110,7 @@ def test_brinkmann_penalise_vector_field_2d(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_brinkmann_penalise_scalar_field_vs_fixed_val_2d(n_values, precision, rng):
+def test_brinkmann_penalise_scalar_field_vs_fixed_val_2d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = BrinkmannPenalisationSolution(rng, n_values, precision)
     penalised_field = np.zeros_like(solution.ref_penalised_field)
@@ -120,7 +118,7 @@ def test_brinkmann_penalise_scalar_field_vs_fixed_val_2d(n_values, precision, rn
         gen_brinkmann_penalise_vs_fixed_val_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
             field_type="scalar",
         )
     )
@@ -142,7 +140,7 @@ def test_brinkmann_penalise_scalar_field_vs_fixed_val_2d(n_values, precision, rn
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_brinkmann_penalise_vector_field_vs_fixed_val_2d(n_values, precision, rng):
+def test_brinkmann_penalise_vector_field_vs_fixed_val_2d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = BrinkmannPenalisationSolution(rng, n_values, precision)
     penalised_vector_field = np.zeros_like(solution.ref_penalised_vector_field)
@@ -150,7 +148,7 @@ def test_brinkmann_penalise_vector_field_vs_fixed_val_2d(n_values, precision, rn
         gen_brinkmann_penalise_vs_fixed_val_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
             field_type="vector",
         )
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_char_func_from_level_set_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_char_func_from_level_set_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_char_func_from_level_set_via_sine_heaviside_pyst_kernel_2d,
@@ -57,7 +58,7 @@ def test_char_func_from_level_set_via_sine_heaviside_pyst_2d(n_values, precision
             blend_width=solution.blend_width,
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     char_func_from_level_set_via_sine_heaviside_pyst_kernel(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_char_func_from_level_set_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_char_func_from_level_set_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -49,7 +47,9 @@ class CharFuncFromLevelSetFuncSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_char_func_from_level_set_via_sine_heaviside_pyst_2d(n_values, precision, rng):
+def test_char_func_from_level_set_via_sine_heaviside_pyst_2d(
+    n_values, precision, rng, max_cpu_count
+):
     real_t = get_real_t(precision)
     solution = CharFuncFromLevelSetFuncSolution(rng, n_values, precision)
     char_func_field = np.zeros_like(solution.ref_char_func_field)
@@ -58,7 +58,7 @@ def test_char_func_from_level_set_via_sine_heaviside_pyst_2d(n_values, precision
             blend_width=solution.blend_width,
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     char_func_from_level_set_via_sine_heaviside_pyst_kernel(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_flux_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_flux_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -43,7 +41,7 @@ class DiffusionFluxSolution:
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
 @pytest.mark.parametrize("reset_ghost_zone", [True, False])
-def test_diffusion_flux_2d(n_values, precision, reset_ghost_zone, rng):
+def test_diffusion_flux_2d(n_values, precision, reset_ghost_zone, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = DiffusionFluxSolution(n_values, rng, precision)
     diffusion_flux = (
@@ -53,7 +51,7 @@ def test_diffusion_flux_2d(n_values, precision, reset_ghost_zone, rng):
     )
     diffusion_flux_pyst_kernel = gen_diffusion_flux_pyst_kernel_2d(
         real_t=real_t,
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         fixed_grid_size=(n_values, n_values),
         reset_ghost_zone=reset_ghost_zone,
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_flux_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_flux_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_diffusion_flux_pyst_kernel_2d,
@@ -52,7 +53,7 @@ def test_diffusion_flux_2d(n_values, precision, reset_ghost_zone, rng):
     )
     diffusion_flux_pyst_kernel = gen_diffusion_flux_pyst_kernel_2d(
         real_t=real_t,
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         fixed_grid_size=(n_values, n_values),
         reset_ghost_zone=reset_ghost_zone,
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_timestep_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_timestep_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_diffusion_timestep_euler_forward_pyst_kernel_2d,
@@ -51,7 +52,7 @@ def test_diffusion_timestep_euler_forward_2d(n_values, precision, rng):
         gen_diffusion_timestep_euler_forward_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     diffusion_timestep_euler_forward_pyst_kernel(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_timestep_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_timestep_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -43,7 +41,7 @@ class DiffusionTimestepSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_diffusion_timestep_euler_forward_2d(n_values, precision, rng):
+def test_diffusion_timestep_euler_forward_2d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = DiffusionTimestepSolution(rng, n_values, precision=precision)
     field = solution.ref_field.copy()
@@ -52,7 +50,7 @@ def test_diffusion_timestep_euler_forward_2d(n_values, precision, rng):
         gen_diffusion_timestep_euler_forward_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     diffusion_timestep_euler_forward_pyst_kernel(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_elementwise_ops_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_elementwise_ops_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_add_fixed_val_pyst_kernel_2d,
@@ -20,7 +21,7 @@ def test_elementwise_sum_pyst_kernel_2d(n_values, precision):
     elementwise_sum_pyst_kernel = gen_elementwise_sum_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     field_1 = 2 * np.ones((n_values, n_values), dtype=real_t)
@@ -41,7 +42,7 @@ def test_vector_field_elementwise_sum_pyst_kernel_2d(n_values, precision):
     elementwise_sum_pyst_kernel = gen_elementwise_sum_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     field_1 = 2 * np.ones((2, n_values, n_values), dtype=real_t)
@@ -62,7 +63,7 @@ def test_set_fixed_val_pyst_kernel_2d(n_values, precision):
     set_fixed_val_pyst_kernel = gen_set_fixed_val_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     field = np.ones((n_values, n_values), dtype=real_t)
@@ -81,7 +82,7 @@ def test_vector_field_set_fixed_val_pyst_kernel_2d(n_values, precision):
     set_fixed_val_pyst_kernel = gen_set_fixed_val_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     field = np.ones((2, n_values, n_values), dtype=real_t)
@@ -101,7 +102,7 @@ def test_elementwise_copy_pyst_kernel_2d(n_values, precision):
     elementwise_copy_pyst_kernel = gen_elementwise_copy_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     field = 2 * np.ones((n_values, n_values), dtype=real_t)
     rhs_field = 3 * np.ones((n_values, n_values), dtype=real_t)
@@ -117,7 +118,7 @@ def test_elementwise_copy_pyst_kernel_2d(n_values, precision):
 def test_elementwise_complex_product_pyst_kernel_2d(n_values, precision):
     real_t = get_real_t(precision)
     elementwise_complex_product_pyst_kernel = gen_elementwise_complex_product_pyst_kernel_2d(
-        real_t=real_t, num_threads=psutil.cpu_count(logical=False)
+        real_t=real_t, num_threads=multiprocessing.cpu_count()
     )
     complex_dtype = np.complex64 if real_t == np.float32 else np.complex128
     field_1 = (1 + 2j) * np.ones((n_values, n_values), dtype=complex_dtype)
@@ -139,7 +140,7 @@ def test_set_fixed_val_at_boundaries_2d(n_values, precision):
     set_fixed_val_at_boundaries = gen_set_fixed_val_at_boundaries_pyst_kernel_2d(
         real_t=real_t,
         width=width,
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     field = np.ones((n_values, n_values), dtype=real_t)
@@ -163,7 +164,7 @@ def test_vector_field_set_fixed_val_at_boundaries_2d(n_values, precision):
     set_fixed_val_at_boundaries = gen_set_fixed_val_at_boundaries_pyst_kernel_2d(
         real_t=real_t,
         width=width,
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     field = np.ones((dim, n_values, n_values), dtype=real_t)
@@ -186,7 +187,7 @@ def test_add_fixed_val_pyst_kernel_2d(n_values, precision):
     add_fixed_val_pyst_kernel = gen_add_fixed_val_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     field = np.ones((n_values, n_values), dtype=real_t)
@@ -207,7 +208,7 @@ def test_vector_field_add_fixed_val_pyst_kernel_2d(n_values, precision):
     add_fixed_val_pyst_kernel = gen_add_fixed_val_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     field = np.ones((2, n_values, n_values), dtype=real_t)
@@ -230,7 +231,7 @@ def test_elementwise_saxpby_pyst_kernel_2d(n_values, precision):
     elementwise_saxpby_pyst_kernel = gen_elementwise_saxpby_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     field_1 = 2 * np.ones((n_values, n_values), dtype=real_t)
@@ -256,7 +257,7 @@ def test_vector_field_elementwise_saxpby_pyst_kernel_2d(n_values, precision):
     elementwise_saxpby_pyst_kernel = gen_elementwise_saxpby_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     field_1 = 2 * np.ones((2, n_values, n_values), dtype=real_t)

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_elementwise_ops_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_elementwise_ops_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -16,12 +14,12 @@ from sopht.utils.precision import get_real_t
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_elementwise_sum_pyst_kernel_2d(n_values, precision):
+def test_elementwise_sum_pyst_kernel_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_sum_pyst_kernel = gen_elementwise_sum_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     field_1 = 2 * np.ones((n_values, n_values), dtype=real_t)
@@ -37,12 +35,12 @@ def test_elementwise_sum_pyst_kernel_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_elementwise_sum_pyst_kernel_2d(n_values, precision):
+def test_vector_field_elementwise_sum_pyst_kernel_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_sum_pyst_kernel = gen_elementwise_sum_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     field_1 = 2 * np.ones((2, n_values, n_values), dtype=real_t)
@@ -58,12 +56,12 @@ def test_vector_field_elementwise_sum_pyst_kernel_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_set_fixed_val_pyst_kernel_2d(n_values, precision):
+def test_set_fixed_val_pyst_kernel_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     set_fixed_val_pyst_kernel = gen_set_fixed_val_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     field = np.ones((n_values, n_values), dtype=real_t)
@@ -77,12 +75,12 @@ def test_set_fixed_val_pyst_kernel_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_set_fixed_val_pyst_kernel_2d(n_values, precision):
+def test_vector_field_set_fixed_val_pyst_kernel_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     set_fixed_val_pyst_kernel = gen_set_fixed_val_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     field = np.ones((2, n_values, n_values), dtype=real_t)
@@ -97,12 +95,12 @@ def test_vector_field_set_fixed_val_pyst_kernel_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_elementwise_copy_pyst_kernel_2d(n_values, precision):
+def test_elementwise_copy_pyst_kernel_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_copy_pyst_kernel = gen_elementwise_copy_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     field = 2 * np.ones((n_values, n_values), dtype=real_t)
     rhs_field = 3 * np.ones((n_values, n_values), dtype=real_t)
@@ -115,10 +113,10 @@ def test_elementwise_copy_pyst_kernel_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_elementwise_complex_product_pyst_kernel_2d(n_values, precision):
+def test_elementwise_complex_product_pyst_kernel_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_complex_product_pyst_kernel = gen_elementwise_complex_product_pyst_kernel_2d(
-        real_t=real_t, num_threads=multiprocessing.cpu_count()
+        real_t=real_t, num_threads=max_cpu_count
     )
     complex_dtype = np.complex64 if real_t == np.float32 else np.complex128
     field_1 = (1 + 2j) * np.ones((n_values, n_values), dtype=complex_dtype)
@@ -134,13 +132,13 @@ def test_elementwise_complex_product_pyst_kernel_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_set_fixed_val_at_boundaries_2d(n_values, precision):
+def test_set_fixed_val_at_boundaries_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     width = 2
     set_fixed_val_at_boundaries = gen_set_fixed_val_at_boundaries_pyst_kernel_2d(
         real_t=real_t,
         width=width,
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     field = np.ones((n_values, n_values), dtype=real_t)
@@ -157,14 +155,14 @@ def test_set_fixed_val_at_boundaries_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_set_fixed_val_at_boundaries_2d(n_values, precision):
+def test_vector_field_set_fixed_val_at_boundaries_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     width = 2
     dim = 2
     set_fixed_val_at_boundaries = gen_set_fixed_val_at_boundaries_pyst_kernel_2d(
         real_t=real_t,
         width=width,
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     field = np.ones((dim, n_values, n_values), dtype=real_t)
@@ -182,12 +180,12 @@ def test_vector_field_set_fixed_val_at_boundaries_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_add_fixed_val_pyst_kernel_2d(n_values, precision):
+def test_add_fixed_val_pyst_kernel_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     add_fixed_val_pyst_kernel = gen_add_fixed_val_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     field = np.ones((n_values, n_values), dtype=real_t)
@@ -203,12 +201,12 @@ def test_add_fixed_val_pyst_kernel_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_add_fixed_val_pyst_kernel_2d(n_values, precision):
+def test_vector_field_add_fixed_val_pyst_kernel_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     add_fixed_val_pyst_kernel = gen_add_fixed_val_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     field = np.ones((2, n_values, n_values), dtype=real_t)
@@ -226,12 +224,12 @@ def test_vector_field_add_fixed_val_pyst_kernel_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_elementwise_saxpby_pyst_kernel_2d(n_values, precision):
+def test_elementwise_saxpby_pyst_kernel_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_saxpby_pyst_kernel = gen_elementwise_saxpby_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     field_1 = 2 * np.ones((n_values, n_values), dtype=real_t)
@@ -252,12 +250,12 @@ def test_elementwise_saxpby_pyst_kernel_2d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_elementwise_saxpby_pyst_kernel_2d(n_values, precision):
+def test_vector_field_elementwise_saxpby_pyst_kernel_2d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_saxpby_pyst_kernel = gen_elementwise_saxpby_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     field_1 = 2 * np.ones((2, n_values, n_values), dtype=real_t)

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_inplane_field_curl_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_inplane_field_curl_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -37,14 +35,14 @@ class InplaneCurlSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_inplane_field_curl(n_values, precision, rng):
+def test_inplane_field_curl(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = InplaneCurlSolution(n_values, rng, precision)
     curl = np.zeros_like(solution.ref_curl)
     inplane_field_curl_kernel = gen_inplane_field_curl_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     inplane_field_curl_kernel(
         curl=curl,

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_inplane_field_curl_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_inplane_field_curl_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_inplane_field_curl_pyst_kernel_2d,
@@ -43,7 +44,7 @@ def test_inplane_field_curl(n_values, precision, rng):
     inplane_field_curl_kernel = gen_inplane_field_curl_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     inplane_field_curl_kernel(
         curl=curl,

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_outplane_field_curl_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_outplane_field_curl_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_outplane_field_curl_pyst_kernel_2d,
@@ -38,7 +39,7 @@ def test_outplane_field_curl(n_values, precision, reset_ghost_zone, rng):
     outplane_field_curl_pyst_kernel = gen_outplane_field_curl_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         reset_ghost_zone=reset_ghost_zone,
     )
     outplane_field_curl_pyst_kernel(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_outplane_field_curl_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_outplane_field_curl_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -32,14 +30,14 @@ class OutplaneCurlSolution:
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
 @pytest.mark.parametrize("reset_ghost_zone", [True, False])
-def test_outplane_field_curl(n_values, precision, reset_ghost_zone, rng):
+def test_outplane_field_curl(n_values, precision, reset_ghost_zone, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = OutplaneCurlSolution(n_values, rng, precision)
     curl = np.ones_like(solution.ref_curl) if reset_ghost_zone else np.zeros_like(solution.ref_curl)
     outplane_field_curl_pyst_kernel = gen_outplane_field_curl_pyst_kernel_2d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         reset_ghost_zone=reset_ghost_zone,
     )
     outplane_field_curl_pyst_kernel(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_penalise_field_boundary_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_penalise_field_boundary_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -67,7 +65,7 @@ class PenaliseFieldBoundarySolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_penalise_field_boundary_2d(n_values, precision, rng):
+def test_penalise_field_boundary_2d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = PenaliseFieldBoundarySolution(n_values, rng, precision)
     field = solution.ref_field.copy()
@@ -78,7 +76,7 @@ def test_penalise_field_boundary_2d(n_values, precision, rng):
         y_grid_field=solution.y_grid_field,
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     penalise_field_towards_boundary_pyst_kernel(field=field)
     solution.check_equals(field)

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_penalise_field_boundary_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_penalise_field_boundary_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_penalise_field_boundary_pyst_kernel_2d,
@@ -77,7 +78,7 @@ def test_penalise_field_boundary_2d(n_values, precision, rng):
         y_grid_field=solution.y_grid_field,
         real_t=real_t,
         fixed_grid_size=(n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     penalise_field_towards_boundary_pyst_kernel(field=field)
     solution.check_equals(field)

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_update_vorticity_from_velocity_forcing_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_update_vorticity_from_velocity_forcing_2d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_update_vorticity_from_penalised_velocity_pyst_kernel_2d,
@@ -57,7 +58,7 @@ def test_update_vorticity_from_velocity_forcing_2d(n_values, precision, rng):
         gen_update_vorticity_from_velocity_forcing_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     update_vorticity_from_velocity_forcing_pyst_kernel(
@@ -85,7 +86,7 @@ def test_update_vorticity_from_penalised_velocity_2d(n_values, precision, rng):
         gen_update_vorticity_from_penalised_velocity_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     update_vorticity_from_penalised_vorticity_kernel(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_update_vorticity_from_velocity_forcing_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_update_vorticity_from_velocity_forcing_2d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -50,7 +48,7 @@ class UpdateVorticityFromVelocityForcingSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_update_vorticity_from_velocity_forcing_2d(n_values, precision, rng):
+def test_update_vorticity_from_velocity_forcing_2d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = UpdateVorticityFromVelocityForcingSolution(n_values, rng, precision)
     vorticity_field = solution.ref_vorticity_field.copy()
@@ -58,7 +56,7 @@ def test_update_vorticity_from_velocity_forcing_2d(n_values, precision, rng):
         gen_update_vorticity_from_velocity_forcing_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     update_vorticity_from_velocity_forcing_pyst_kernel(
@@ -71,7 +69,7 @@ def test_update_vorticity_from_velocity_forcing_2d(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_update_vorticity_from_penalised_velocity_2d(n_values, precision, rng):
+def test_update_vorticity_from_penalised_velocity_2d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     vorticity_field = rng.random((n_values, n_values)).astype(real_t)
     velocity_field = rng.random((2, n_values, n_values)).astype(real_t)
@@ -86,7 +84,7 @@ def test_update_vorticity_from_penalised_velocity_2d(n_values, precision, rng):
         gen_update_vorticity_from_penalised_velocity_pyst_kernel_2d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     update_vorticity_from_penalised_vorticity_kernel(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_advection_flux_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_advection_flux_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -182,7 +180,7 @@ class AdvectionSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_advection_flux_cons_eno3_3d(n_values, precision, rng):
+def test_advection_flux_cons_eno3_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = AdvectionSolution(n_values, rng, flux_type="conservative_eno3", precision=precision)
     advection_flux = np.zeros_like(solution.ref_advection_flux)
@@ -190,7 +188,7 @@ def test_advection_flux_cons_eno3_3d(n_values, precision, rng):
         gen_advection_flux_conservative_eno3_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     advection_flux_conservative_eno3_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_advection_flux_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_advection_flux_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_advection_flux_conservative_eno3_pyst_kernel_3d,
@@ -189,7 +190,7 @@ def test_advection_flux_cons_eno3_3d(n_values, precision, rng):
         gen_advection_flux_conservative_eno3_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     advection_flux_conservative_eno3_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_advection_timestep_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_advection_timestep_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_3d,
@@ -106,7 +107,7 @@ def test_advection_eno3_euler_forward(n_values, precision, rng):
         gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
             field_type="scalar",
         )
     )
@@ -136,7 +137,7 @@ def test_vector_field_advection_timestep_eno3_3d(n_values, precision, rng):
         gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
             field_type="vector",
         )
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_advection_timestep_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_advection_timestep_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -93,7 +91,7 @@ class AdvectionTimestepEulerForwardSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_advection_eno3_euler_forward(n_values, precision, rng):
+def test_advection_eno3_euler_forward(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = AdvectionTimestepEulerForwardSolution(
         n_values,
@@ -107,7 +105,7 @@ def test_advection_eno3_euler_forward(n_values, precision, rng):
         gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
             field_type="scalar",
         )
     )
@@ -122,7 +120,7 @@ def test_advection_eno3_euler_forward(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_advection_timestep_eno3_3d(n_values, precision, rng):
+def test_vector_field_advection_timestep_eno3_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = AdvectionTimestepEulerForwardSolution(
         n_values,
@@ -137,7 +135,7 @@ def test_vector_field_advection_timestep_eno3_3d(n_values, precision, rng):
         gen_advection_timestep_euler_forward_conservative_eno3_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
             field_type="vector",
         )
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_brinkmann_penalise_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_brinkmann_penalise_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -69,14 +67,14 @@ class BrinkmannPenalisationSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_brinkmann_penalise_scalar_field_3d(n_values, precision, rng):
+def test_brinkmann_penalise_scalar_field_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = BrinkmannPenalisationSolution(n_values, rng, precision)
     penalised_field = np.zeros_like(solution.ref_penalised_field)
     brinkmann_penalise_pyst_openmp_kernel_3d = gen_brinkmann_penalise_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     brinkmann_penalise_pyst_openmp_kernel_3d(
@@ -92,14 +90,14 @@ def test_brinkmann_penalise_scalar_field_3d(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_brinkmann_penalise_vector_field_3d(n_values, precision, rng):
+def test_brinkmann_penalise_vector_field_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = BrinkmannPenalisationSolution(n_values, rng, precision)
     penalised_vector_field = np.zeros_like(solution.ref_penalised_vector_field)
     brinkmann_penalise_vector_field_pyst_openmp_kernel_3d = gen_brinkmann_penalise_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     brinkmann_penalise_vector_field_pyst_openmp_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_brinkmann_penalise_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_brinkmann_penalise_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_brinkmann_penalise_pyst_kernel_3d,
@@ -75,7 +76,7 @@ def test_brinkmann_penalise_scalar_field_3d(n_values, precision, rng):
     brinkmann_penalise_pyst_openmp_kernel_3d = gen_brinkmann_penalise_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     brinkmann_penalise_pyst_openmp_kernel_3d(
@@ -98,7 +99,7 @@ def test_brinkmann_penalise_vector_field_3d(n_values, precision, rng):
     brinkmann_penalise_vector_field_pyst_openmp_kernel_3d = gen_brinkmann_penalise_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     brinkmann_penalise_vector_field_pyst_openmp_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_char_func_from_level_set_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_char_func_from_level_set_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -49,7 +47,9 @@ class CharFuncFromLevelSetFuncSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_char_func_from_level_set_via_sine_heaviside_pyst_3d(n_values, precision, rng):
+def test_char_func_from_level_set_via_sine_heaviside_pyst_3d(
+    n_values, precision, rng, max_cpu_count
+):
     real_t = get_real_t(precision)
     solution = CharFuncFromLevelSetFuncSolution(n_values, rng, precision)
     char_func_field = np.zeros_like(solution.ref_char_func_field)
@@ -58,7 +58,7 @@ def test_char_func_from_level_set_via_sine_heaviside_pyst_3d(n_values, precision
             blend_width=solution.blend_width,
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     char_func_from_level_set_via_sine_heaviside_pyst_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_char_func_from_level_set_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_char_func_from_level_set_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_char_func_from_level_set_via_sine_heaviside_pyst_kernel_3d,
@@ -57,7 +58,7 @@ def test_char_func_from_level_set_via_sine_heaviside_pyst_3d(n_values, precision
             blend_width=solution.blend_width,
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     char_func_from_level_set_via_sine_heaviside_pyst_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_curl_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_curl_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -77,14 +75,14 @@ class CurlSolution:
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
 @pytest.mark.parametrize("reset_ghost_zone", [True, False])
-def test_curl_3d(n_values, precision, reset_ghost_zone, rng):
+def test_curl_3d(n_values, precision, reset_ghost_zone, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = CurlSolution(n_values, rng, precision)
     curl = np.ones_like(solution.ref_curl) if reset_ghost_zone else np.zeros_like(solution.ref_curl)
     curl_pyst_kernel_3d = gen_curl_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         reset_ghost_zone=reset_ghost_zone,
     )
     curl_pyst_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_curl_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_curl_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_curl_pyst_kernel_3d,
@@ -83,7 +84,7 @@ def test_curl_3d(n_values, precision, reset_ghost_zone, rng):
     curl_pyst_kernel_3d = gen_curl_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         reset_ghost_zone=reset_ghost_zone,
     )
     curl_pyst_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_diffusion_flux_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_diffusion_flux_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -77,7 +75,7 @@ class DiffusionFluxSolution:
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
 @pytest.mark.parametrize("reset_ghost_zone", [True, False])
-def test_diffusion_flux_3d(n_values, precision, reset_ghost_zone, rng):
+def test_diffusion_flux_3d(n_values, precision, reset_ghost_zone, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = DiffusionFluxSolution(n_values, rng, precision)
     diffusion_flux = (
@@ -88,7 +86,7 @@ def test_diffusion_flux_3d(n_values, precision, reset_ghost_zone, rng):
     diffusion_flux_pyst_openmp_kernel_3d = gen_diffusion_flux_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
         reset_ghost_zone=reset_ghost_zone,
     )
@@ -103,7 +101,7 @@ def test_diffusion_flux_3d(n_values, precision, reset_ghost_zone, rng):
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
 @pytest.mark.parametrize("reset_ghost_zone", [True, False])
-def test_vector_field_diffusion_flux_3d(n_values, precision, reset_ghost_zone, rng):
+def test_vector_field_diffusion_flux_3d(n_values, precision, reset_ghost_zone, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = DiffusionFluxSolution(n_values, rng, precision)
     vector_field_diffusion_flux = (
@@ -114,7 +112,7 @@ def test_vector_field_diffusion_flux_3d(n_values, precision, reset_ghost_zone, r
     vector_field_diffusion_flux_pyst_kernel_3d = gen_diffusion_flux_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
         reset_ghost_zone=reset_ghost_zone,
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_diffusion_flux_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_diffusion_flux_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_diffusion_flux_pyst_kernel_3d,
@@ -87,7 +88,7 @@ def test_diffusion_flux_3d(n_values, precision, reset_ghost_zone, rng):
     diffusion_flux_pyst_openmp_kernel_3d = gen_diffusion_flux_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
         reset_ghost_zone=reset_ghost_zone,
     )
@@ -113,7 +114,7 @@ def test_vector_field_diffusion_flux_3d(n_values, precision, reset_ghost_zone, r
     vector_field_diffusion_flux_pyst_kernel_3d = gen_diffusion_flux_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
         reset_ghost_zone=reset_ghost_zone,
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_diffusion_timestep_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_diffusion_timestep_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_diffusion_timestep_euler_forward_pyst_kernel_3d,
@@ -81,7 +82,7 @@ def test_diffusion_timestep_euler_forward_3d(n_values, precision, rng):
         gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
             field_type="scalar",
         )
     )
@@ -104,7 +105,7 @@ def test_vector_field_diffusion_timestep_euler_forward_3d(n_values, precision, r
         gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
             field_type="vector",
         )
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_diffusion_timestep_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_diffusion_timestep_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -73,7 +71,7 @@ class DiffusionTimestepEulerForwardSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_diffusion_timestep_euler_forward_3d(n_values, precision, rng):
+def test_diffusion_timestep_euler_forward_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = DiffusionTimestepEulerForwardSolution(n_values, rng, precision)
     field = solution.ref_field.copy()
@@ -82,7 +80,7 @@ def test_diffusion_timestep_euler_forward_3d(n_values, precision, rng):
         gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
             field_type="scalar",
         )
     )
@@ -96,7 +94,7 @@ def test_diffusion_timestep_euler_forward_3d(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_diffusion_timestep_euler_forward_3d(n_values, precision, rng):
+def test_vector_field_diffusion_timestep_euler_forward_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = DiffusionTimestepEulerForwardSolution(n_values, rng, precision)
     vector_field = solution.ref_vector_field.copy()
@@ -105,7 +103,7 @@ def test_vector_field_diffusion_timestep_euler_forward_3d(n_values, precision, r
         gen_diffusion_timestep_euler_forward_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
             field_type="vector",
         )
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_divergence_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_divergence_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_divergence_pyst_kernel_3d,
@@ -57,7 +58,7 @@ def test_divergence_3d(n_values, precision, reset_ghost_zone, rng):
     divergence_pyst_kernel_3d = gen_divergence_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         reset_ghost_zone=reset_ghost_zone,
     )
     divergence_pyst_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_divergence_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_divergence_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -47,7 +45,7 @@ class DivergenceSolution:
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
 @pytest.mark.parametrize("reset_ghost_zone", [True, False])
-def test_divergence_3d(n_values, precision, reset_ghost_zone, rng):
+def test_divergence_3d(n_values, precision, reset_ghost_zone, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = DivergenceSolution(n_values, rng, precision)
     divergence = (
@@ -58,7 +56,7 @@ def test_divergence_3d(n_values, precision, reset_ghost_zone, rng):
     divergence_pyst_kernel_3d = gen_divergence_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         reset_ghost_zone=reset_ghost_zone,
     )
     divergence_pyst_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_elementwise_ops_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_elementwise_ops_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_add_fixed_val_pyst_kernel_3d,
@@ -21,7 +22,7 @@ def test_elementwise_sum_pyst_kernel_3d(n_values, precision):
     elementwise_sum_pyst_kernel = gen_elementwise_sum_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     field_1 = 2 * np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -42,7 +43,7 @@ def test_vector_field_elementwise_sum_pyst_kernel_3d(n_values, precision):
     elementwise_sum_pyst_kernel = gen_elementwise_sum_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     field_1 = 2 * np.ones((3, n_values, n_values, n_values), dtype=real_t)
@@ -63,7 +64,7 @@ def test_set_fixed_val_pyst_kernel_3d(n_values, precision):
     set_fixed_val_pyst_kernel = gen_set_fixed_val_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     field = np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -82,7 +83,7 @@ def test_vector_field_set_fixed_val_pyst_kernel_3d(n_values, precision):
     set_fixed_val_pyst_kernel = gen_set_fixed_val_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     field = np.ones((3, n_values, n_values, n_values), dtype=real_t)
@@ -103,7 +104,7 @@ def test_elementwise_copy_pyst_kernel_3d(n_values, precision):
     elementwise_copy_pyst_kernel = gen_elementwise_copy_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     field = 2 * np.ones((n_values, n_values, n_values), dtype=real_t)
     rhs_field = 3 * np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -119,7 +120,7 @@ def test_elementwise_copy_pyst_kernel_3d(n_values, precision):
 def test_elementwise_complex_product_pyst_kernel_3d(n_values, precision):
     real_t = get_real_t(precision)
     elementwise_complex_product_pyst_kernel = gen_elementwise_complex_product_pyst_kernel_3d(
-        real_t=real_t, num_threads=psutil.cpu_count(logical=False)
+        real_t=real_t, num_threads=multiprocessing.cpu_count()
     )
     complex_dtype = np.complex64 if real_t == np.float32 else np.complex128
     field_1 = (1 + 2j) * np.ones((n_values, n_values, n_values), dtype=complex_dtype)
@@ -141,7 +142,7 @@ def test_set_fixed_val_at_boundaries_3d(n_values, precision):
     set_fixed_val_at_boundaries = gen_set_fixed_val_at_boundaries_pyst_kernel_3d(
         real_t=real_t,
         width=width,
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     field = np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -167,7 +168,7 @@ def test_vector_field_set_fixed_val_at_boundaries_3d(n_values, precision):
     set_fixed_val_at_boundaries = gen_set_fixed_val_at_boundaries_pyst_kernel_3d(
         real_t=real_t,
         width=width,
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     field = np.ones((dim, n_values, n_values, n_values), dtype=real_t)
@@ -191,7 +192,7 @@ def test_add_fixed_val_pyst_kernel_3d(n_values, precision):
     add_fixed_val_pyst_kernel = gen_add_fixed_val_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     field = np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -212,7 +213,7 @@ def test_vector_field_add_fixed_val_pyst_kernel_3d(n_values, precision):
     add_fixed_val_pyst_kernel = gen_add_fixed_val_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     field = np.ones((3, n_values, n_values, n_values), dtype=real_t)
@@ -237,7 +238,7 @@ def test_elementwise_saxpby_pyst_kernel_3d(n_values, precision):
     elementwise_saxpby_pyst_kernel = gen_elementwise_saxpby_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="scalar",
     )
     field_1 = 2 * np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -263,7 +264,7 @@ def test_vector_field_elementwise_saxpby_pyst_kernel_3d(n_values, precision):
     elementwise_saxpby_pyst_kernel = gen_elementwise_saxpby_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type="vector",
     )
     field_1 = 2 * np.ones((3, n_values, n_values, n_values), dtype=real_t)
@@ -290,7 +291,7 @@ def test_elementwise_cross_product_pyst_kernel_3d(n_values, precision):
     elementwise_cross_product_pyst_kernel = gen_elementwise_cross_product_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     field_1 = np.zeros((dim, n_values, n_values, n_values), dtype=real_t)
     field_1 += np.array([1.0, 2.0, 3.0]).reshape(dim, 1, 1, 1)

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_elementwise_ops_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_elementwise_ops_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -17,12 +15,12 @@ from sopht.utils.precision import get_real_t
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_elementwise_sum_pyst_kernel_3d(n_values, precision):
+def test_elementwise_sum_pyst_kernel_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_sum_pyst_kernel = gen_elementwise_sum_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     field_1 = 2 * np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -38,12 +36,12 @@ def test_elementwise_sum_pyst_kernel_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_elementwise_sum_pyst_kernel_3d(n_values, precision):
+def test_vector_field_elementwise_sum_pyst_kernel_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_sum_pyst_kernel = gen_elementwise_sum_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     field_1 = 2 * np.ones((3, n_values, n_values, n_values), dtype=real_t)
@@ -59,12 +57,12 @@ def test_vector_field_elementwise_sum_pyst_kernel_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_set_fixed_val_pyst_kernel_3d(n_values, precision):
+def test_set_fixed_val_pyst_kernel_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     set_fixed_val_pyst_kernel = gen_set_fixed_val_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     field = np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -78,12 +76,12 @@ def test_set_fixed_val_pyst_kernel_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_set_fixed_val_pyst_kernel_3d(n_values, precision):
+def test_vector_field_set_fixed_val_pyst_kernel_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     set_fixed_val_pyst_kernel = gen_set_fixed_val_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     field = np.ones((3, n_values, n_values, n_values), dtype=real_t)
@@ -99,12 +97,12 @@ def test_vector_field_set_fixed_val_pyst_kernel_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_elementwise_copy_pyst_kernel_3d(n_values, precision):
+def test_elementwise_copy_pyst_kernel_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_copy_pyst_kernel = gen_elementwise_copy_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     field = 2 * np.ones((n_values, n_values, n_values), dtype=real_t)
     rhs_field = 3 * np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -117,10 +115,10 @@ def test_elementwise_copy_pyst_kernel_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_elementwise_complex_product_pyst_kernel_3d(n_values, precision):
+def test_elementwise_complex_product_pyst_kernel_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_complex_product_pyst_kernel = gen_elementwise_complex_product_pyst_kernel_3d(
-        real_t=real_t, num_threads=multiprocessing.cpu_count()
+        real_t=real_t, num_threads=max_cpu_count
     )
     complex_dtype = np.complex64 if real_t == np.float32 else np.complex128
     field_1 = (1 + 2j) * np.ones((n_values, n_values, n_values), dtype=complex_dtype)
@@ -136,13 +134,13 @@ def test_elementwise_complex_product_pyst_kernel_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_set_fixed_val_at_boundaries_3d(n_values, precision):
+def test_set_fixed_val_at_boundaries_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     width = 2
     set_fixed_val_at_boundaries = gen_set_fixed_val_at_boundaries_pyst_kernel_3d(
         real_t=real_t,
         width=width,
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     field = np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -161,14 +159,14 @@ def test_set_fixed_val_at_boundaries_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_set_fixed_val_at_boundaries_3d(n_values, precision):
+def test_vector_field_set_fixed_val_at_boundaries_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     width = 2
     dim = 3
     set_fixed_val_at_boundaries = gen_set_fixed_val_at_boundaries_pyst_kernel_3d(
         real_t=real_t,
         width=width,
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     field = np.ones((dim, n_values, n_values, n_values), dtype=real_t)
@@ -187,12 +185,12 @@ def test_vector_field_set_fixed_val_at_boundaries_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_add_fixed_val_pyst_kernel_3d(n_values, precision):
+def test_add_fixed_val_pyst_kernel_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     add_fixed_val_pyst_kernel = gen_add_fixed_val_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     field = np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -208,12 +206,12 @@ def test_add_fixed_val_pyst_kernel_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_add_fixed_val_pyst_kernel_3d(n_values, precision):
+def test_vector_field_add_fixed_val_pyst_kernel_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     add_fixed_val_pyst_kernel = gen_add_fixed_val_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     field = np.ones((3, n_values, n_values, n_values), dtype=real_t)
@@ -233,12 +231,12 @@ def test_vector_field_add_fixed_val_pyst_kernel_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_elementwise_saxpby_pyst_kernel_3d(n_values, precision):
+def test_elementwise_saxpby_pyst_kernel_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_saxpby_pyst_kernel = gen_elementwise_saxpby_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="scalar",
     )
     field_1 = 2 * np.ones((n_values, n_values, n_values), dtype=real_t)
@@ -259,12 +257,12 @@ def test_elementwise_saxpby_pyst_kernel_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vector_field_elementwise_saxpby_pyst_kernel_3d(n_values, precision):
+def test_vector_field_elementwise_saxpby_pyst_kernel_3d(n_values, precision, max_cpu_count):
     real_t = get_real_t(precision)
     elementwise_saxpby_pyst_kernel = gen_elementwise_saxpby_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type="vector",
     )
     field_1 = 2 * np.ones((3, n_values, n_values, n_values), dtype=real_t)
@@ -285,13 +283,13 @@ def test_vector_field_elementwise_saxpby_pyst_kernel_3d(n_values, precision):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_elementwise_cross_product_pyst_kernel_3d(n_values, precision):
+def test_elementwise_cross_product_pyst_kernel_3d(n_values, precision, max_cpu_count):
     dim = 3
     real_t = get_real_t(precision)
     elementwise_cross_product_pyst_kernel = gen_elementwise_cross_product_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     field_1 = np.zeros((dim, n_values, n_values, n_values), dtype=real_t)
     field_1 += np.array([1.0, 2.0, 3.0]).reshape(dim, 1, 1, 1)

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_laplacian_filter_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_laplacian_filter_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_laplacian_filter_kernel_3d,
@@ -132,7 +133,7 @@ def test_laplacian_filter_constant_field(
         filter_flux_buffer=filter_flux_buffer,
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type=field_type,
         filter_type=filter_type,
     )
@@ -171,7 +172,7 @@ def test_laplacian_filter_random_field(
         filter_flux_buffer=filter_flux_buffer,
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type=field_type,
         filter_type=filter_type,
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_laplacian_filter_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_laplacian_filter_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -108,11 +106,7 @@ def vector_laplacian_filter(vector_field: np.ndarray, filter_order: int, filter_
 @pytest.mark.parametrize("field_type", ["scalar", "vector"])
 @pytest.mark.parametrize("filter_type", ["convolution", "multiplicative"])
 def test_laplacian_filter_constant_field(
-    n_values,
-    precision,
-    filter_order,
-    field_type,
-    filter_type,
+    n_values, precision, filter_order, field_type, filter_type, max_cpu_count
 ):
     real_t = get_real_t(precision)
     dim = 3
@@ -133,7 +127,7 @@ def test_laplacian_filter_constant_field(
         filter_flux_buffer=filter_flux_buffer,
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type=field_type,
         filter_type=filter_type,
     )
@@ -147,12 +141,7 @@ def test_laplacian_filter_constant_field(
 @pytest.mark.parametrize("field_type", ["scalar", "vector"])
 @pytest.mark.parametrize("filter_type", ["convolution", "multiplicative"])
 def test_laplacian_filter_random_field(
-    n_values,
-    precision,
-    filter_order,
-    field_type,
-    filter_type,
-    rng,
+    n_values, precision, filter_order, field_type, filter_type, rng, max_cpu_count
 ):
     real_t = get_real_t(precision)
     dim = 3
@@ -172,7 +161,7 @@ def test_laplacian_filter_random_field(
         filter_flux_buffer=filter_flux_buffer,
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type=field_type,
         filter_type=filter_type,
     )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_penalise_field_boundary_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_penalise_field_boundary_3d.py
@@ -1,7 +1,7 @@
+import multiprocessing
 from typing import Literal
 
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_penalise_field_boundary_pyst_kernel_3d,
@@ -126,7 +126,7 @@ def test_penalise_field_boundary_3d(
         z_grid_field=solution.z_grid_field,
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type=field_type,
     )
     match field_type:
@@ -156,7 +156,7 @@ def test_zero_width_penalise_field_boundary_3d(
         z_grid_field=solution.z_grid_field,
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
         field_type=field_type,
     )
     match field_type:

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_penalise_field_boundary_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_penalise_field_boundary_3d.py
@@ -1,4 +1,3 @@
-import multiprocessing
 from typing import Literal
 
 import numpy as np
@@ -114,7 +113,7 @@ class PenaliseFieldBoundarySolution:
 @pytest.mark.parametrize("n_values", [16])
 @pytest.mark.parametrize("field_type", ["scalar", "vector"])
 def test_penalise_field_boundary_3d(
-    n_values, precision, field_type: Literal["scalar", "vector"], rng
+    n_values, precision, field_type: Literal["scalar", "vector"], rng, max_cpu_count
 ):
     real_t = get_real_t(precision)
     solution = PenaliseFieldBoundarySolution(n_values, rng, precision)
@@ -126,7 +125,7 @@ def test_penalise_field_boundary_3d(
         z_grid_field=solution.z_grid_field,
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type=field_type,
     )
     match field_type:
@@ -144,7 +143,7 @@ def test_penalise_field_boundary_3d(
 @pytest.mark.parametrize("n_values", [16])
 @pytest.mark.parametrize("field_type", ["scalar", "vector"])
 def test_zero_width_penalise_field_boundary_3d(
-    n_values, precision, field_type: Literal["scalar", "vector"], rng
+    n_values, precision, field_type: Literal["scalar", "vector"], rng, max_cpu_count
 ):
     real_t = get_real_t(precision)
     solution = PenaliseFieldBoundarySolution(n_values, rng, precision)
@@ -156,7 +155,7 @@ def test_zero_width_penalise_field_boundary_3d(
         z_grid_field=solution.z_grid_field,
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
         field_type=field_type,
     )
     match field_type:

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_update_vorticity_from_velocity_forcing_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_update_vorticity_from_velocity_forcing_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_update_vorticity_from_penalised_velocity_pyst_kernel_3d,
@@ -84,7 +85,7 @@ def test_update_vorticity_from_velocity_forcing_3d(n_values, precision, rng):
         gen_update_vorticity_from_velocity_forcing_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     update_vorticity_from_velocity_forcing_pyst_kernel(
@@ -112,7 +113,7 @@ def test_update_vorticity_from_penalised_velocity_3d(n_values, precision, rng):
         gen_update_vorticity_from_penalised_velocity_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     update_vorticity_from_penalised_vorticity_kernel(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_update_vorticity_from_velocity_forcing_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_update_vorticity_from_velocity_forcing_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -77,7 +75,7 @@ class UpdateVorticityFromVelocityForcingSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_update_vorticity_from_velocity_forcing_3d(n_values, precision, rng):
+def test_update_vorticity_from_velocity_forcing_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = UpdateVorticityFromVelocityForcingSolution(n_values, rng, precision)
     vorticity_field = solution.ref_vorticity_field.copy()
@@ -85,7 +83,7 @@ def test_update_vorticity_from_velocity_forcing_3d(n_values, precision, rng):
         gen_update_vorticity_from_velocity_forcing_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     update_vorticity_from_velocity_forcing_pyst_kernel(
@@ -98,7 +96,7 @@ def test_update_vorticity_from_velocity_forcing_3d(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_update_vorticity_from_penalised_velocity_3d(n_values, precision, rng):
+def test_update_vorticity_from_penalised_velocity_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     vorticity_field = rng.random((3, n_values, n_values, n_values)).astype(real_t)
     velocity_field = rng.random((3, n_values, n_values, n_values)).astype(real_t)
@@ -113,7 +111,7 @@ def test_update_vorticity_from_penalised_velocity_3d(n_values, precision, rng):
         gen_update_vorticity_from_penalised_velocity_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     update_vorticity_from_penalised_vorticity_kernel(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_vorticity_stretching_flux_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_vorticity_stretching_flux_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -62,14 +60,14 @@ class VorticityStretchingFluxSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vort_stretching_flux_3d(n_values, precision, rng):
+def test_vort_stretching_flux_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = VorticityStretchingFluxSolution(n_values, rng, precision)
     vorticity_stretching_flux_field = np.zeros_like(solution.ref_vorticity_stretching_flux_field)
     vorticity_stretching_flux_kernel_3d = gen_vorticity_stretching_flux_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     vorticity_stretching_flux_kernel_3d(
         vorticity_stretching_flux_field=vorticity_stretching_flux_field,

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_vorticity_stretching_flux_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_vorticity_stretching_flux_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_vorticity_stretching_flux_pyst_kernel_3d,
@@ -68,7 +69,7 @@ def test_vort_stretching_flux_3d(n_values, precision, rng):
     vorticity_stretching_flux_kernel_3d = gen_vorticity_stretching_flux_pyst_kernel_3d(
         real_t=real_t,
         fixed_grid_size=(n_values, n_values, n_values),
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     vorticity_stretching_flux_kernel_3d(
         vorticity_stretching_flux_field=vorticity_stretching_flux_field,

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_vorticity_stretching_timestep_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_vorticity_stretching_timestep_3d.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
     gen_vorticity_stretching_timestep_euler_forward_pyst_kernel_3d,
@@ -93,7 +94,7 @@ def test_vort_stretching_timestep_euler_forward_3d(n_values, precision, rng):
         gen_vorticity_stretching_timestep_euler_forward_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     vorticity_stretching_timestep_euler_forward_pyst_kernel_3d(
@@ -119,7 +120,7 @@ def test_vort_stretching_timestep_ssprk3_3d(n_values, precision, rng):
             real_t=real_t,
             midstep_buffer_vector_field=np.zeros_like(vorticity_field),
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=psutil.cpu_count(logical=False),
+            num_threads=multiprocessing.cpu_count(),
         )
     )
     vorticity_stretching_timestep_ssprk3_pyst_kernel_3d(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_vorticity_stretching_timestep_3d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_3d/test_vorticity_stretching_timestep_3d.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.eulerian_grid_ops import (
@@ -83,7 +81,7 @@ class VorticityStretchingTimestepSolution:
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vort_stretching_timestep_euler_forward_3d(n_values, precision, rng):
+def test_vort_stretching_timestep_euler_forward_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = VorticityStretchingTimestepSolution(
         n_values, rng, time_stepper="euler_forward", precision=precision
@@ -94,7 +92,7 @@ def test_vort_stretching_timestep_euler_forward_3d(n_values, precision, rng):
         gen_vorticity_stretching_timestep_euler_forward_pyst_kernel_3d(
             real_t=real_t,
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     vorticity_stretching_timestep_euler_forward_pyst_kernel_3d(
@@ -108,7 +106,7 @@ def test_vort_stretching_timestep_euler_forward_3d(n_values, precision, rng):
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("n_values", [16])
-def test_vort_stretching_timestep_ssprk3_3d(n_values, precision, rng):
+def test_vort_stretching_timestep_ssprk3_3d(n_values, precision, rng, max_cpu_count):
     real_t = get_real_t(precision)
     solution = VorticityStretchingTimestepSolution(
         n_values, rng, time_stepper="ssprk3", precision=precision
@@ -120,7 +118,7 @@ def test_vort_stretching_timestep_ssprk3_3d(n_values, precision, rng):
             real_t=real_t,
             midstep_buffer_vector_field=np.zeros_like(vorticity_field),
             fixed_grid_size=(n_values, n_values, n_values),
-            num_threads=multiprocessing.cpu_count(),
+            num_threads=max_cpu_count,
         )
     )
     vorticity_stretching_timestep_ssprk3_pyst_kernel_3d(

--- a/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing.py
+++ b/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing.py
@@ -1,5 +1,6 @@
+import multiprocessing
+
 import numpy as np
-import psutil
 import pytest
 from sopht.numeric.immersed_boundary_ops import VirtualBoundaryForcing
 from sopht.utils.precision import get_real_t, get_test_tol
@@ -365,7 +366,7 @@ def test_compute_interaction_with_eul_grid_forcing_reset(grid_dim, n_values, pre
         num_lag_nodes=mock_soln.num_lag_nodes,
         real_t=mock_soln.real_t,
         enable_eul_grid_forcing_reset=True,
-        num_threads=psutil.cpu_count(logical=False),
+        num_threads=multiprocessing.cpu_count(),
     )
     eul_grid_velocity_shape = (grid_dim,) + (n_values,) * grid_dim
     eul_grid_forcing_field = rng.random(eul_grid_velocity_shape).astype(real_t)

--- a/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing.py
+++ b/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing.py
@@ -1,5 +1,3 @@
-import multiprocessing
-
 import numpy as np
 import pytest
 from sopht.numeric.immersed_boundary_ops import VirtualBoundaryForcing
@@ -350,7 +348,9 @@ def test_compute_interaction_without_eul_grid_forcing_reset(grid_dim, n_values, 
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("grid_dim", [2, 3])
 @pytest.mark.parametrize("n_values", [16])
-def test_compute_interaction_with_eul_grid_forcing_reset(grid_dim, n_values, precision, rng):
+def test_compute_interaction_with_eul_grid_forcing_reset(
+    grid_dim, n_values, precision, rng, max_cpu_count
+):
     real_t = get_real_t(precision)
     mock_soln = MockVirtualBoundaryForcingSolution(
         grid_size=n_values,
@@ -366,7 +366,7 @@ def test_compute_interaction_with_eul_grid_forcing_reset(grid_dim, n_values, pre
         num_lag_nodes=mock_soln.num_lag_nodes,
         real_t=mock_soln.real_t,
         enable_eul_grid_forcing_reset=True,
-        num_threads=multiprocessing.cpu_count(),
+        num_threads=max_cpu_count,
     )
     eul_grid_velocity_shape = (grid_dim,) + (n_values,) * grid_dim
     eul_grid_forcing_field = rng.random(eul_grid_velocity_shape).astype(real_t)

--- a/uv.lock
+++ b/uv.lock
@@ -1080,28 +1080,6 @@ wheels = [
 ]
 
 [[package]]
-name = "psutil"
-version = "7.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
-    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
-    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
-    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
-    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
-]
-
-[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1550,7 +1528,6 @@ lint = [
 tests = [
     { name = "coverage" },
     { name = "mypy" },
-    { name = "psutil" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -1579,7 +1556,6 @@ lint = [{ name = "ruff" }]
 tests = [
     { name = "coverage" },
     { name = "mypy" },
-    { name = "psutil" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]


### PR DESCRIPTION
Replace `psutil.cpu_count(logical=False)` with a pytest fixture which invokes `os.cpu_count()` and fall back to 1. This allows us to remove `psutil` from the dependency list. 

One caveat here is that the `logical=False` flag allows `psutil` to return the physical core count, while `os.cpu_count` and may include hyperthreads. However, this is not a big issue because most uses case have users prescribe a thread count. Furthermore, `psutil` is so far only used in test cases. Therefore we can safely make this change.